### PR TITLE
feat: Implement universal PDF report generation for all printers

### DIFF
--- a/node-red/flows.json
+++ b/node-red/flows.json
@@ -3560,6 +3560,16 @@
         "wires": []
     },
     {
+        "id": "a9b8c7d6.e5f44a",
+        "type": "subflow:c2b1a6a9.e3bbf8",
+        "z": "c4582a5c3c4d6d09",
+        "g": "39cad17b39cec1d1",
+        "name": "Generate PDF Report",
+        "x": 2100,
+        "y": 700,
+        "wires": []
+    },
+    {
         "id": "ada47b8b28f15571",
         "type": "debug",
         "z": "44c225e855f817f8",
@@ -4018,8 +4028,8 @@
         "z": "c4582a5c3c4d6d09",
         "g": "39cad17b39cec1d1",
         "name": "Parse PrusaLink Data",
-        "func": "// --- Get data from previous nodes ---\nconst printer_response = msg.printer_api_response;\nconst job_response = msg.payload;\nconst device = msg.original_device_config;\nconst last_status = flow.get('printer_status_' + device.device_id) || {};\n\n// --- Safety Check ---\nif (!printer_response || !printer_response.state) {\n    node.warn(`No valid /printer response for ${device.friendly_name}. Skipping.`);\n    return null;\n}\n\n// --- Parse Current and Previous States ---\nconst stateFlags = printer_response.state?.flags ?? {};\nconst is_printing_now = stateFlags.printing ?? false;\nconst was_printing = last_status.is_printing ?? false;\nconst current_filename = job_response?.job?.file?.name ?? null;\n\n\n// --- FIX: Robust State Change Logic ---\n\n// --- Event 1: A new print has started ---\nif (is_printing_now && !was_printing && current_filename) {\n    const new_job_msg = {\n        topic: \"CREATE_NEW_PRUSA_JOB\",\n        query: `\n            INSERT INTO print_jobs (device_id, filename, status, start_time)\n            VALUES ($1, $2, 'printing', NOW());\n        `,\n        params: [device.device_id, current_filename]\n    };\n\n    // Send the message to create the job record (Output 3)\n    // We create a clone of the original msg to send, which is good practice.\n    node.send([null, null, new_job_msg]);\n\n    // **CRITICAL FIX**: Only update the state *after* handling the \"job start\" event.\n    flow.set('printer_status_' + device.device_id, {\n        is_printing: true,\n        filename: current_filename,\n        device_id: device.device_id\n    });\n\n    // --- Event 2: A print has just finished ---\n} else if (was_printing && !is_printing_now) {\n    const end_of_job_msg = {\n        topic: \"CALCULATE_FINAL_ENERGY\",\n        params: [last_status.device_id, last_status.filename]\n    };\n\n    const update_job_status_msg = {\n        topic: \"UPDATE_PRUSA_JOB_STATUS\",\n        query: `\n            UPDATE print_jobs \n            SET status = 'done', end_time = NOW(), duration_seconds = EXTRACT(EPOCH FROM (NOW() - start_time))\n            WHERE device_id = $1 AND filename = $2 AND status = 'printing';\n        `,\n        params: [last_status.device_id, last_status.filename]\n    };\n\n    // Send messages for job completion events (Outputs 2 and 3)\n    node.send([null, end_of_job_msg, update_job_status_msg]);\n\n    // **CRITICAL FIX**: Update the state to reflect the printer is no longer printing.\n    flow.set('printer_status_' + device.device_id, {\n        is_printing: false,\n        filename: null, // Clear the filename\n        device_id: device.device_id\n    });\n}\n\n// --- Prepare the main status insert message for Output 1 ---\n// This part runs on every poll, regardless of state changes.\nconst params = [\n    new Date().toISOString(), // 1\n    device.device_id, // 2\n    printer_response.state?.text ?? 'Unknown', // 3\n    stateFlags.operational ?? false, // 4\n    is_printing_now, // 5\n    stateFlags.paused ?? false, // 6\n    stateFlags.error ?? false, // 7\n    stateFlags.busy ?? false, // 8\n    printer_response.temperature?.tool0?.actual ?? null, // 9\n    printer_response.temperature?.tool0?.target ?? null, // 10\n    printer_response.temperature?.bed?.actual ?? null, // 11\n    printer_response.temperature?.bed?.target ?? null, // 12\n    printer_response.telemetry?.material ?? null, // 13\n    current_filename, // 14\n    (job_response?.progress?.completion ?? 0) * 100, // 15\n    job_response?.progress?.printTimeLeft ?? null, // 16\n    null // 17 (Placeholder for ambient_temp_c)\n];\n\n// Pass the main status message to Output 1\nmsg.params = params;\nreturn msg;",
-        "outputs": 3,
+        "func": "// --- Get data from previous nodes ---\nconst printer_response = msg.printer_api_response;\nconst job_response = msg.payload;\nconst device = msg.original_device_config;\nconst last_status = flow.get('printer_status_' + device.device_id) || {};\n\n// --- Initialize Output Messages ---\nlet msg_status_update = null;\nlet msg_end_of_job = null;\nlet msg_job_db_action = null;\nlet msg_pdf_trigger = null;\n\n// --- Safety Check ---\nif (!printer_response || !printer_response.state) {\n    node.warn(`No valid /printer response for ${device.friendly_name}. Skipping.`);\n    return null; // Stop the flow completely for this device\n}\n\n// --- Parse Current and Previous States ---\nconst stateFlags = printer_response.state?.flags ?? {};\nconst is_printing_now = stateFlags.printing ?? false;\nconst was_printing = last_status.is_printing ?? false;\nconst current_filename = job_response?.job?.file?.name ?? null;\n\n// --- State Change Logic ---\nif (is_printing_now && !was_printing && current_filename) {\n    // --- Event 1: A new print has started ---\n    msg_job_db_action = {\n        topic: \"CREATE_NEW_PRUSA_JOB\",\n        query: `\n            INSERT INTO print_jobs (device_id, filename, status, start_time)\n            VALUES ($1, $2, 'printing', NOW());\n        `,\n        params: [device.device_id, current_filename]\n    };\n    \n    flow.set('printer_status_' + device.device_id, {\n        is_printing: true,\n        filename: current_filename,\n        device_id: device.device_id\n    });\n\n} else if (was_printing && !is_printing_now) {\n    // --- Event 2: A print has just finished ---\n    msg_end_of_job = {\n        topic: \"CALCULATE_FINAL_ENERGY\",\n        params: [last_status.device_id, last_status.filename]\n    };\n\n    msg_job_db_action = {\n        topic: \"UPDATE_PRUSA_JOB_STATUS\",\n        query: `\n            UPDATE print_jobs \n            SET status = 'done', end_time = NOW(), duration_seconds = EXTRACT(EPOCH FROM (NOW() - start_time))\n            WHERE device_id = $1 AND filename = $2 AND status = 'printing';\n        `,\n        params: [last_status.device_id, last_status.filename]\n    };\n    \n    // NEW: Trigger PDF Generation\n    msg_pdf_trigger = {\n        topic: \"GENERATE_PDF_REPORT\",\n        payload: {\n            device_id: last_status.device_id,\n            filename: last_status.filename\n        }\n    };\n\n    flow.set('printer_status_' + device.device_id, {\n        is_printing: false,\n        filename: null,\n        device_id: device.device_id\n    });\n}\n\n// --- Prepare the main status insert message (always runs) ---\nconst status_params = [\n    new Date().toISOString(),\n    device.device_id,\n    printer_response.state?.text ?? 'Unknown',\n    stateFlags.operational ?? false,\n    is_printing_now,\n    stateFlags.paused ?? false,\n    stateFlags.error ?? false,\n    stateFlags.busy ?? false,\n    printer_response.temperature?.tool0?.actual ?? null,\n    printer_response.temperature?.tool0?.target ?? null,\n    printer_response.temperature?.bed?.actual ?? null,\n    printer_response.temperature?.bed?.target ?? null,\n    printer_response.telemetry?.material ?? null,\n    current_filename,\n    (job_response?.progress?.completion ?? 0) * 100,\n    job_response?.progress?.printTimeLeft ?? null,\n    null // Placeholder for ambient_temp_c\n];\n\nmsg_status_update = { params: status_params };\n\n// Return all messages for their respective outputs\nreturn [msg_status_update, msg_end_of_job, msg_job_db_action, msg_pdf_trigger];",
+        "outputs": 4,
         "timeout": "",
         "noerr": 0,
         "initialize": "",
@@ -4040,6 +4050,9 @@
             [
                 "3893c4f9f6dfef59",
                 "1a68329a7809840d"
+            ],
+            [
+                "a9b8c7d6.e5f44a"
             ]
         ]
     },
@@ -4083,6 +4096,15 @@
         "y": 480,
         "wires": [],
         "l": true
+    },
+    {
+        "id": "f4d3b3a3.7b3b4c",
+        "type": "subflow:c2b1a6a9.e3bbf8",
+        "z": "088fab733419c707",
+        "name": "Generate PDF Report",
+        "x": 1500,
+        "y": 560,
+        "wires": []
     },
     {
         "id": "5dda7fb58e2cb2a2",
@@ -5111,7 +5133,7 @@
         "z": "088fab733419c707",
         "g": "2406f1dc5d32b76a",
         "name": "Parse and Merge All Data",
-        "func": "// --- Get data from previous nodes --- \nconst job_details = msg.payload.job;\nconst live_data = msg.live_data;\nconst device = msg.original_device_config;\nconst last_status = flow.get('printer_status_' + device.device_id) || {};\n\n// --- Find the correct printer ---\nconst target_printer_id = parseInt(device.simplyprint_id, 10);\nconst api_response_data = live_data.data?.find(p => p.id === target_printer_id);\n\nif (!api_response_data) {\n    node.error(`Parse/Merge Error: Did not find printer with ID ${target_printer_id}.`, msg);\n    return null;\n}\n\n// --- Unify the Filename and State ---\nconst current_filename = job_details?.file || api_response_data.job?.file || null;\nconst stateText = api_response_data.printer?.state?.charAt(0).toUpperCase() + api_response_data.printer.state.slice(1) || 'Unknown';\nconst is_printing_now = ['printing', 'heating'].includes(stateText.toLowerCase());\nconst was_printing = last_status.is_printing ?? false;\n\n// --- Initialize all outgoing messages ---\nlet msg_job_upsert = null;\nlet msg_status_update = null;\nlet msg_end_of_job = null;\nlet msg_start_energy_trigger = null;\nlet msg_gcode_analysis_trigger = null;\nlet msg_pdf_generation_trigger = null; // New message for PDF generation\n\n// --- Job Completion Detection ---\nif (was_printing && !is_printing_now && last_status.filename) {\n    msg_end_of_job = {\n        topic: \"CALCULATE_FINAL_ENERGY\",\n        params: [last_status.device_id, last_status.filename]\n    };\n\n    // --- NEW: Trigger PDF Generation on Job Completion ---\n    if (job_details && job_details.id) {\n        msg_pdf_generation_trigger = {\n            method: \"POST\",\n            url: \"http://python-api:5000/api/generate_dpp_pdf\",\n            headers: {\n                'Content-Type': 'application/json'\n            },\n            payload: {\n                job_id: job_details.id.toString()\n            }\n        };\n    }\n}\n\n// --- Update flow memory for the NEXT cycle ---\nflow.set('printer_status_' + device.device_id, {\n    is_printing: is_printing_now,\n    filename: current_filename,\n    device_id: device.device_id\n});\n\n// --- Prepare Status Update ---\nmsg_status_update = {\n    topic: \"INSERT_PRINTER_STATUS\",\n    params: [\n        new Date().toISOString(), // 1\n        device.device_id, // 2\n        stateText, // 3\n        stateText.toLowerCase() !== 'offline', // 4\n        is_printing_now, // 5\n        stateText.toLowerCase() === 'paused', // 6\n        stateText.toLowerCase() === 'error', // 7\n        ['printing', 'paused', 'heating'].includes(stateText.toLowerCase()), // 8\n        api_response_data.printer.temps?.current?.tool?.[0] ?? null, // 9\n        api_response_data.printer.temps?.target?.tool?.[0] ?? null, // 10\n        api_response_data.printer.temps?.current?.bed ?? null, // 11\n        api_response_data.printer.temps?.target?.bed ?? null, // 12\n        api_response_data.filament?.[0]?.type?.name ?? null, // 13\n        current_filename, // 14\n        api_response_data.job?.percentage ?? null, // 15\n        api_response_data.job?.time ?? null, // 16\n        api_response_data.printer.temps?.ambient ?? null // 17\n    ]\n};\n\n// --- Prepare Job Upsert, Triggers, and NEW Part Metadata Logic ---\nif (job_details && job_details.id) {\n    const gcodeAnalysis = job_details.analysis ? JSON.stringify(job_details.analysis) : null;\n    let filamentGrams = null;\n    if (job_details.filament?.e0?.fil?.[0]?.gram) {\n        filamentGrams = job_details.filament.e0.fil[0].gram;\n    }\n\n    let partMetadata = null;\n    if (Array.isArray(job_details.customFields) && job_details.customFields.length > 0) {\n        const modelDataField = job_details.customFields.find(field => field.id === 'modeldata');\n        if (modelDataField && modelDataField.value && typeof modelDataField.value.string === 'string') {\n            let rawString = modelDataField.value.string;\n            try {\n                const startIndex = rawString.indexOf('[');\n                const endIndex = rawString.lastIndexOf(']');\n                if (startIndex !== -1 && endIndex !== -1 && endIndex > startIndex) {\n                    let jsonArrayString = rawString.substring(startIndex, endIndex + 1);\n                    jsonArrayString = jsonArrayString.replace(/'/g, '\"');\n                    partMetadata = JSON.parse(jsonArrayString);\n                } else {\n                    node.warn(`Could not find a JSON array '[...]' in modelData string: ${rawString}`);\n                }\n            } catch (e) {\n                node.warn(`Could not parse cleaned modelData for job ${job_details.id}. Error: ${e.message}`);\n            }\n        }\n    }\n\n    msg_job_upsert = {\n        topic: \"UPSERT_PRINT_JOB\",\n        params: [\n            job_details.id.toString(),\n            device.device_id,\n            job_details.started,\n            job_details.ended,\n            job_details.totalPrintTime,\n            job_details.state,\n            current_filename,\n            filamentGrams,\n            gcodeAnalysis,\n            partMetadata ? JSON.stringify(partMetadata) : null,\n            job_details.analysis?.nozzleSize ?? null,\n            msg.payload.filament?.[0]?.dia ?? null\n        ]\n    };\n\n    if (is_printing_now && !was_printing && current_filename) {\n        msg_start_energy_trigger = {\n            topic: \"RECORD_START_ENERGY\",\n            params: [device.device_id, current_filename]\n        };\n    }\n\n    if (current_filename && device.gcode_preview_host && device.gcode_preview_api_key) {\n        msg_gcode_analysis_trigger = {\n            topic: \"ANALYZE_GCODE\",\n            job_id: job_details.id.toString(),\n            filename: current_filename,\n            gcode_host: device.gcode_preview_host,\n            gcode_api_key: device.gcode_preview_api_key,\n            job_details: job_details,\n            original_device_config: device\n        };\n    }\n}\n\nreturn [msg_job_upsert, msg_status_update, msg_end_of_job, msg_start_energy_trigger, msg_gcode_analysis_trigger, msg_pdf_generation_trigger];",
+        "func": "// --- Get data from previous nodes --- \nconst job_details = msg.payload.job;\nconst live_data = msg.live_data;\nconst device = msg.original_device_config;\nconst last_status = flow.get('printer_status_' + device.device_id) || {};\n\n// --- Find the correct printer ---\nconst target_printer_id = parseInt(device.simplyprint_id, 10);\nconst api_response_data = live_data.data?.find(p => p.id === target_printer_id);\n\nif (!api_response_data) {\n    node.error(`Parse/Merge Error: Did not find printer with ID ${target_printer_id}.`, msg);\n    return null;\n}\n\n// --- Unify the Filename and State ---\nconst current_filename = job_details?.file || api_response_data.job?.file || null;\nconst stateText = api_response_data.printer?.state?.charAt(0).toUpperCase() + api_response_data.printer.state.slice(1) || 'Unknown';\nconst is_printing_now = ['printing', 'heating'].includes(stateText.toLowerCase());\nconst was_printing = last_status.is_printing ?? false;\n\n// --- Initialize all outgoing messages ---\nlet msg_job_upsert = null;\nlet msg_status_update = null;\nlet msg_end_of_job = null;\nlet msg_start_energy_trigger = null;\nlet msg_gcode_analysis_trigger = null;\nlet msg_pdf_generation_trigger = null; // New message for PDF generation\n\n// --- Job Completion Detection ---\nif (was_printing && !is_printing_now && last_status.filename) {\n    msg_end_of_job = {\n        topic: \"CALCULATE_FINAL_ENERGY\",\n        params: [last_status.device_id, last_status.filename]\n    };\n\n    // NEW: Trigger PDF generation when a job finishes\n    if (job_details && job_details.id) {\n        node.log(`Job finished. Triggering PDF generation for SimplyPrint job ID: ${job_details.id}`);\n        msg_pdf_generation_trigger = {\n            topic: \"GENERATE_PDF_REPORT\",\n            payload: {\n                simplyprint_job_id: job_details.id.toString()\n            }\n        };\n    }\n}\n\n// --- Update flow memory for the NEXT cycle ---\nflow.set('printer_status_' + device.device_id, {\n    is_printing: is_printing_now,\n    filename: current_filename,\n    device_id: device.device_id\n});\n\n// --- Prepare Status Update ---\n// --- Prepare Status Update ---\nmsg_status_update = {\n    topic: \"INSERT_PRINTER_STATUS\",\n    params: [\n        new Date().toISOString(), // 1\n        device.device_id, // 2\n        stateText, // 3\n        stateText.toLowerCase() !== 'offline', // 4\n        is_printing_now, // 5\n        stateText.toLowerCase() === 'paused', // 6\n        stateText.toLowerCase() === 'error', // 7\n        ['printing', 'paused', 'heating'].includes(stateText.toLowerCase()), // 8\n        api_response_data.printer.temps?.current?.tool?.[0] ?? null, // 9\n        api_response_data.printer.temps?.target?.tool?.[0] ?? null, // 10\n        api_response_data.printer.temps?.current?.bed ?? null, // 11\n        api_response_data.printer.temps?.target?.bed ?? null, // 12\n        api_response_data.filament?.[0]?.type?.name ?? null, // 13\n        current_filename, // 14\n        api_response_data.job?.percentage ?? null, // 15\n        api_response_data.job?.time ?? null, // 16\n        // THE NEW PARAMETER\n        api_response_data.printer.temps?.ambient ?? null // 17\n    ]\n};\n\n// --- Prepare Job Upsert, Triggers, and NEW Part Metadata Logic ---\nif (job_details && job_details.id) {\n    const gcodeAnalysis = job_details.analysis ? JSON.stringify(job_details.analysis) : null;\n    let filamentGrams = null;\n    if (job_details.filament?.e0?.fil?.[0]?.gram) {\n        filamentGrams = job_details.filament.e0.fil[0].gram;\n    }\n\n// ================== NEW LOGIC START ==================\nlet partMetadata = null;\nif (Array.isArray(job_details.customFields) && job_details.customFields.length > 0) {\n    const modelDataField = job_details.customFields.find(field => field.id === 'modeldata');\n    \n    if (modelDataField && modelDataField.value && typeof modelDataField.value.string === 'string') {\n        let rawString = modelDataField.value.string;\n        \n        try {\n            // Find the first occurrence of '['\n            const startIndex = rawString.indexOf('[');\n            // Find the last occurrence of ']'\n            const endIndex = rawString.lastIndexOf(']');\n            \n            if (startIndex !== -1 && endIndex !== -1 && endIndex > startIndex) {\n                // Extract the substring between the first '[' and last ']'\n                let jsonArrayString = rawString.substring(startIndex, endIndex + 1);\n                \n                // Replace all single quotes with double quotes\n                jsonArrayString = jsonArrayString.replace(/'/g, '\"');\n                \n                // Parse the clean string\n                partMetadata = JSON.parse(jsonArrayString);\n            } else {\n                node.warn(`Could not find a JSON array '[...]' in modelData string: ${rawString}`);\n            }\n\n        } catch (e) {\n            node.warn(`Could not parse cleaned modelData for job ${job_details.id}. Error: ${e.message}`);\n        }\n    }\n}\n// =================== NEW LOGIC END ===================\n    msg_job_upsert = {\n        topic: \"UPSERT_PRINT_JOB\",\n        params: [\n            job_details.id.toString(), // 1\n            device.device_id, // 2\n            job_details.started, // 3\n            job_details.ended, // 4\n            job_details.totalPrintTime, // 5\n\n            // CORRECTED: Use the detailed state from the job_details\n            job_details.state, // 6\n\n            current_filename, // 7\n            filamentGrams, // 8\n            gcodeAnalysis, // 9\n            partMetadata ? JSON.stringify(partMetadata) : null, // 10\n\n            // NEW PARAMETERS\n            job_details.analysis?.nozzleSize ?? null, // 11 - Get nozzle size from analysis\n            msg.payload.filament?.[0]?.dia ?? null // 12 - Get filament diameter from main payload\n        ]\n    };\n\n    if (is_printing_now && !was_printing && current_filename) {\n        msg_start_energy_trigger = {\n            topic: \"RECORD_START_ENERGY\",\n            params: [device.device_id, current_filename]\n        };\n    }\n\n    if (current_filename && device.gcode_preview_host && device.gcode_preview_api_key) {\n        msg_gcode_analysis_trigger = {\n            topic: \"ANALYZE_GCODE\",\n            job_id: job_details.id.toString(),\n            filename: current_filename,\n            gcode_host: device.gcode_preview_host,\n            gcode_api_key: device.gcode_preview_api_key,\n            job_details: job_details,\n            original_device_config: device\n        };\n    }\n}\n\nreturn [msg_job_upsert, msg_status_update, msg_end_of_job, msg_start_energy_trigger, msg_gcode_analysis_trigger, msg_pdf_generation_trigger];",
         "outputs": 6,
         "timeout": "",
         "noerr": 0,
@@ -5137,7 +5159,7 @@
                 "548b0a238325e0b8"
             ],
             [
-                "c74a8a1a.a3a5e8"
+                "f4d3b3a3.7b3b4c"
             ]
         ],
         "info": "**Purpose:** The central processing hub of this entire flow. It merges all available data sources (live poll, detailed job API) and determines what actions need to be taken.\r\n\r\n**Logic:**\r\n1.  Detects job start/end transitions and prepares trigger messages for energy calculations.\r\n2.  Standardizes the printer status data for insertion into the `printer_status` table.\r\n3.  Parses the `modelData` from the `customFields` array.\r\n4.  Prepares a complete message with all job details (`filament_used_g`, `part_metadata`, etc.) for insertion into the `print_jobs` table.\r\n5.  Prepares a trigger message for the G-code analysis pipeline if a job is active.\r\n\r\n**Outputs:** This node has 5 outputs, each sending a different, specialized message to a `link out` node to trigger a specific action in the main flow or other subflows."
@@ -5408,50 +5430,8 @@
         "wires": [
             [
                 "a849c171e8e54fe4"
-            ],
-            [
-                "c74a8a1a.a3a5e8",
-                "a9d3a4e9.1c2d28"
             ]
         ]
-    },
-    {
-        "id": "c74a8a1a.a3a5e8",
-        "type": "http request",
-        "z": "088fab733419c707",
-        "name": "Generate DPP Report PDF",
-        "method": "POST",
-        "ret": "txt",
-        "paytoqs": "ignore",
-        "url": "http://python-api:5000/api/generate_dpp_pdf",
-        "tls": "",
-        "persist": false,
-        "proxy": "",
-        "authType": "",
-        "x": 1600,
-        "y": 560,
-        "wires": [
-            [
-                "a9d3a4e9.1c2d28"
-            ]
-        ]
-    },
-    {
-        "id": "a9d3a4e9.1c2d28",
-        "type": "debug",
-        "z": "088fab733419c707",
-        "name": "PDF Generation Status",
-        "active": true,
-        "tosidebar": true,
-        "console": false,
-        "tostatus": true,
-        "complete": "payload",
-        "targetType": "msg",
-        "statusVal": "payload",
-        "statusType": "auto",
-        "x": 1820,
-        "y": 560,
-        "wires": []
     },
     {
         "id": "856d2b19e2a0d021",
@@ -5821,6 +5801,156 @@
         "info": "**Purpose:** Constructs a single, powerful SQL query to calculate and save the final energy consumption for a completed print job.\n\n**Triggered By:** The job completion detection logic in the main flows.\n\n**Logic:**\n- The query uses a Common Table Expression (CTE) to get the *latest* `energy_total_wh` for the device.\n- It then performs an `UPDATE` on the `print_jobs` table.\n- It calculates `session_energy_wh` by subtracting the job's `start_energy_wh` (stored at the beginning of the print) from the latest `energy_total_wh`.\n- This atomic operation ensures the calculation is accurate and efficient.",
         "x": 560,
         "y": 280,
+        "wires": []
+    },
+    {
+        "id": "c2b1a6a9.e3bbf8",
+        "type": "subflow",
+        "name": "Generate PDF Report",
+        "info": "This subflow generates a PDF report for a completed print job.",
+        "category": "",
+        "in": [
+            {
+                "x": 40,
+                "y": 80,
+                "wires": [
+                    {
+                        "id": "a1b2c3d4.e5f6g7"
+                    }
+                ]
+            }
+        ],
+        "out": [],
+        "env": []
+    },
+    {
+        "id": "a1b2c3d4.e5f6g7",
+        "type": "switch",
+        "z": "c2b1a6a9.e3bbf8",
+        "name": "Check Input Type",
+        "property": "payload.simplyprint_job_id",
+        "propertyType": "msg",
+        "rules": [
+            {
+                "t": "nnull"
+            },
+            {
+                "t": "else"
+            }
+        ],
+        "checkall": "true",
+        "repair": false,
+        "outputs": 2,
+        "x": 170,
+        "y": 80,
+        "wires": [
+            [
+                "b1c2d3e4.f5g6h7"
+            ],
+            [
+                "c1d2e3f4.g5h6i7"
+            ]
+        ]
+    },
+    {
+        "id": "b1c2d3e4.f5g6h7",
+        "type": "postgresql",
+        "z": "c2b1a6a9.e3bbf8",
+        "name": "Get job_id from simplyprint_job_id",
+        "query": "SELECT job_id FROM print_jobs WHERE simplyprint_job_id = $1",
+        "postgreSQLConfig": "4259e91acb63e17b",
+        "split": false,
+        "rowsPerMsg": 1,
+        "outputs": 1,
+        "x": 420,
+        "y": 40,
+        "wires": [
+            [
+                "d1e2f3g4.h5i6j7"
+            ]
+        ]
+    },
+    {
+        "id": "c1d2e3f4.g5h6i7",
+        "type": "postgresql",
+        "z": "c2b1a6a9.e3bbf8",
+        "name": "Get job_id from device_id and filename",
+        "query": "SELECT job_id FROM print_jobs WHERE device_id = $1 AND filename = $2 ORDER BY end_time DESC LIMIT 1",
+        "postgreSQLConfig": "4259e91acb63e17b",
+        "split": false,
+        "rowsPerMsg": 1,
+        "outputs": 1,
+        "x": 450,
+        "y": 120,
+        "wires": [
+            [
+                "d1e2f3g4.h5i6j7"
+            ]
+        ]
+    },
+    {
+        "id": "d1e2f3g4.h5i6j7",
+        "type": "change",
+        "z": "c2b1a6a9.e3bbf8",
+        "name": "Prepare PDF Request",
+        "rules": [
+            {
+                "t": "set",
+                "p": "payload",
+                "pt": "msg",
+                "to": "{\n    \"job_id\": msg.payload[0].job_id\n}",
+                "tot": "json"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 700,
+        "y": 80,
+        "wires": [
+            [
+                "e1f2g3h4.i5j6k7"
+            ]
+        ]
+    },
+    {
+        "id": "e1f2g3h4.i5j6k7",
+        "type": "http request",
+        "z": "c2b1a6a9.e3bbf8",
+        "name": "Generate PDF",
+        "method": "POST",
+        "ret": "txt",
+        "paytoqs": "ignore",
+        "url": "http://python-api:5000/api/generate_dpp_pdf",
+        "tls": "",
+        "persist": false,
+        "proxy": "",
+        "authType": "",
+        "x": 880,
+        "y": 80,
+        "wires": [
+            [
+                "f1g2h3i4.j5k6l7"
+            ]
+        ]
+    },
+    {
+        "id": "f1g2h3i4.j5k6l7",
+        "type": "debug",
+        "z": "c2b1a6a9.e3bbf8",
+        "name": "PDF Generation Status",
+        "active": true,
+        "tosidebar": true,
+        "console": false,
+        "tostatus": true,
+        "complete": "payload",
+        "targetType": "msg",
+        "statusVal": "payload",
+        "statusType": "auto",
+        "x": 1060,
+        "y": 80,
         "wires": []
     }
 ]


### PR DESCRIPTION
This commit fixes a bug where the 'Report' PDF download button was not appearing for completed print jobs.

The root cause was that the PDF generation API was never being called after a job finished. Additionally, the initial attempt to fix this was flawed as it only targeted SimplyPrint printers and used an incorrect job identifier.

This commit introduces a robust and universal solution by:

1.  Creating a new, reusable 'Generate PDF Report' sub-flow in Node-RED. This sub-flow is responsible for taking job identifiers (either from SimplyPrint or Prusa), querying the database to find the correct internal 'job_id', and calling the PDF generation API.

2.  Integrating this sub-flow into the 'Historical Enrichment' flow. When a SimplyPrint job completes, it now triggers this sub-flow.

3.  Integrating the same sub-flow into the 'Master Ingestion Flow'. When a Prusa printer job completes, it also triggers this sub-flow.

This new architecture ensures that PDF reports are generated correctly for all printer types and centralizes the generation logic, making it more maintainable.